### PR TITLE
normalize usages of '.NET' per branding guidelines

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -15,7 +15,7 @@ or try one of our online tutorials:
 
    * [Javascript/NodeJS](tutorials/javascript/)
    * [Java](tutorials/java/)
-   * [Dotnet](tutorials/dotnet/)
+   * [.NET](tutorials/dotnet/)
    * More languages coming soon!
 
 Metaparticle is a work in progress.

--- a/content/tutorials/dotnet-sharding.md
+++ b/content/tutorials/dotnet-sharding.md
@@ -1,10 +1,10 @@
 ---
-title: "Metaparticle/Sharding for Dotnet"
+title: "Metaparticle/Sharding for .NET"
 date: 2017-11-21
 draft: false
 ---
 
-## Metaparticle/Sharding for Dotnet Tutorial
+## Metaparticle/Sharding for .NET Tutorial
 
 _Note, this is an advanced tutorial, please start with the [initial tutorial](tutorial.md)_
 
@@ -39,7 +39,7 @@ A diagram of the shard architecture is below
 Typically a shard deployment would consist of two different application containers (the router and the shard), two different deployment configurations and two services to connect pieces together. That's a lot of YAML and a lot of complexity for an enduser to
 absorb to implement a fairly straightforward concept.
 
-To show how Metaparticle/Sharding can help dramatically simplify this, here is the corresponding code in Dotnet:
+To show how Metaparticle/Sharding can help dramatically simplify this, here is the corresponding code in .NET:
 
 ```cs
 using System.IO;

--- a/content/tutorials/dotnet-sync.md
+++ b/content/tutorials/dotnet-sync.md
@@ -1,15 +1,15 @@
 ---
-title: "Metaparticle Distributed Synchronization for Dotnet"
+title: "Metaparticle Distributed Synchronization for .NET"
 date: 2017-11-21
 draft: false
 ---
 
-# Examples MetaParticle Sync library for Dotnet Core
+# Examples MetaParticle Sync library for .NET
 
-Metaparticle/Sync for Dotnet Core is a library that implements distributed synchronization
+Metaparticle/Sync for .NET is a library that implements distributed synchronization
 for cloud-native applications using a container side-car and Kubernetes primitives.
 
-Metaparticle/Sync for Dotnet Core can be used for [locking](#locking-example) or for
+Metaparticle/Sync for .NET can be used for [locking](#locking-example) or for
 [leader election](#election-example)
 
 ## Adding the Library

--- a/content/tutorials/dotnet.md
+++ b/content/tutorials/dotnet.md
@@ -1,10 +1,10 @@
 ---
-title: "Metaparticle for Dotnet"
+title: "Metaparticle for .NET"
 date: 2017-11-21
 draft: false
 ---
 
-# Metaparticle/Package for Dotnet Tutorial
+# Metaparticle/Package for .NET Tutorial
 This is an in-depth tutorial for using Metaparticle/Package for Java
 
 For a quick summary, please see the [about metaparticle](/about/).

--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -9,17 +9,17 @@ accomplish a variety of different development tasks, in a variety of languages.
 ## Deploying Containers & Replicated Services
    * [Javascript/NodeJS](/tutorials/javascript/)
    * [Java](/tutorials/java/)
-   * [Dotnet](/tutorials/dotnet/)
+   * [.NET](/tutorials/dotnet/)
 
 ## Distributed Synchronization: Locks & Election
    * [Javascript/NodeJS](/tutorials/javascript-sync/)
    * [Java](/tutorials/java-sync/)
-   * [Dotnet](/tutorials/dotnet-sync/)
+   * [.NET](/tutorials/dotnet-sync/)
 
 ## Container native patterns: Sharding
    * [Javascript/NodeJS](javascript-sharding/)
    * [Java](java-sharding/)
-   * [Dotnet](dotnet-sharding/)
+   * [.NET](dotnet-sharding/)
 
 ## More coming soon
 


### PR DESCRIPTION
While the CLI is called `dotnet`, any usages referring to the framework itself should be ".NET" ([all caps](https://twitter.com/terrajobst/status/933004220701097984))

I also removed the "Core" from the sync page since these packages target `netstandard` and therefore can be used with other implementations (such as the full .NET Framework, mono, etc.)