### PR TITLE
Fix links in sharding tutorials

### DIFF
--- a/content/tutorials/dotnet-sharding.md
+++ b/content/tutorials/dotnet-sharding.md
@@ -6,7 +6,7 @@ draft: false
 
 ## Metaparticle/Sharding for .NET Tutorial
 
-_Note, this is an advanced tutorial, please start with the [initial tutorial](tutorial.md)_
+_Note, this is an advanced tutorial, please start with the [initial tutorial](/tutorials/dotnet) for .NET_
 
 ### Sharding
 Sharding is the process of dividing requests between a server using some characteristic 

--- a/content/tutorials/index.md
+++ b/content/tutorials/index.md
@@ -17,9 +17,9 @@ accomplish a variety of different development tasks, in a variety of languages.
    * [.NET](/tutorials/dotnet-sync/)
 
 ## Container native patterns: Sharding
-   * [Javascript/NodeJS](javascript-sharding/)
-   * [Java](java-sharding/)
-   * [.NET](dotnet-sharding/)
+   * [Javascript/NodeJS](/tutorials/javascript-sharding/)
+   * [Java](/tutorials/java-sharding/)
+   * [.NET](/tutorials/dotnet-sharding/)
 
 ## More coming soon
 

--- a/content/tutorials/java-sharding.md
+++ b/content/tutorials/java-sharding.md
@@ -6,7 +6,7 @@ draft: false
 
 ## Metaparticle/Sharding for Java Tutorial
 
-_Note, this is an advanced tutorial, please start with the [initial tutorial](tutorial.md)_
+_Note, this is an advanced tutorial, please start with the [initial tutorial](/tutorials/java) for Java_
 
 ### Sharding
 Sharding is the process of dividing requests between a server using some characteristic 

--- a/content/tutorials/javascript-sharding.md
+++ b/content/tutorials/javascript-sharding.md
@@ -6,7 +6,7 @@ draft: false
 
 ## Metaparticle/Sharding for Javascript Tutorial
 
-_Note, this is an advanced tutorial, please start with the [initial tutorial](tutorial.md)_
+_Note, this is an advanced tutorial, please start with the [initial tutorial](/tutorials/javascript) for JavaScript_
 
 ### Sharding
 Sharding is the process of dividing requests between a server using some characteristic 


### PR DESCRIPTION
Resolves https://github.com/metaparticle-io/package/issues/16

Note this fixes the static site but kind of breaks the docs when they're copied over into the package repo because of the different directory structure.
ex: https://github.com/metaparticle-io/package/blob/master/tutorials/javascript/